### PR TITLE
chore(repo): add PR template and contributing guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+# Title
+<!-- Use Conventional Commits PR title: feat(scope): ..., fix(scope): ..., chore(scope): ..., refactor(scope): ... -->
+
+## Related ticket
+Closes #
+
+## What changed
+- 
+
+## Why
+- 
+
+## How to test
+1. 
+
+## Screenshots (optional)
+
+## Notes (optional)

--- a/.github/semantic-pull-requests.yml
+++ b/.github/semantic-pull-requests.yml
@@ -1,0 +1,19 @@
+# If you later enable the Semantic Pull Requests GitHub App,
+# this config defines allowed types/scopes.
+types:
+  - feat
+  - fix
+  - chore
+  - refactor
+  - docs
+  - test
+  - ci
+scopes:
+  - ui
+  - lists
+  - items
+  - picker
+  - auth
+  - db
+  - infra
+requireScope: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+## Branching & PRs
+- `main` is protected — **no direct pushes**.
+- Create a branch and open a PR.
+- Prefer **Squash merge**.
+
+## PR title format (Conventional Commits)
+Use:
+
+```
+<type>(<scope>): <summary>
+```
+
+### Types
+- `feat` — new user-facing functionality
+- `fix` — bug fix
+- `refactor` — code change that neither fixes a bug nor adds a feature
+- `chore` — tooling, config, maintenance
+- `docs` — documentation
+- `test` — tests
+- `ci` — CI changes
+
+### Scopes (suggested)
+- `ui`, `lists`, `items`, `picker`, `auth`, `db`, `infra`
+
+### Examples
+- `feat(lists): add create list button`
+- `fix(ui): add button hover styles`
+- `chore(db): document DATABASE_URL env var`
+
+## Issue writing style
+Prefer acceptance criteria using GIVEN / WHEN / THEN scenarios (see issue templates).


### PR DESCRIPTION
## Related ticket
N/A

## What changed
- Added `.github/PULL_REQUEST_TEMPLATE.md`
- Added `CONTRIBUTING.md` (PR title conventions + workflow)
- Added `.github/semantic-pull-requests.yml` (future-proof config if you enable the Semantic PRs app)

## Why
Standardize PR format and enforce best practices (main protected, conventional titles).

## How to test
1. Open PR creation UI and verify the PR template appears.
2. Verify CONTRIBUTING.md is readable.

## Notes
If you want automatic enforcement of PR title format, enable the **Semantic Pull Requests** GitHub App (optional).