### PR TITLE
fix(ui): Tailwind v4 theme tokens for shadcn utilities

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,44 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/*
+  Tailwind v4 + shadcn/ui note:
+  We define CSS variables for design tokens (below) and map them to Tailwind color tokens via @theme.
+  This enables utilities like bg-background, text-foreground, border-border, etc.
+*/
+
+@theme inline {
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
+
+  --radius: var(--radius);
+}
+
 :root {
   /* Light theme (kept simple for now) */
   --background: 210 40% 98%;
@@ -51,7 +89,7 @@
   --primary: 142.1 70.6% 45.3%; /* ~ #22C55E */
   --primary-foreground: 144.9 80.4% 10%;
 
-  --secondary: 215 40% 18%; /* slightly lighter navy */
+  --secondary: 215 40% 18%;
   --secondary-foreground: 213 100% 95%;
 
   --muted: 215 35% 18%;


### PR DESCRIPTION
## Related ticket
N/A

## What changed
- Added `@theme inline { ... }` mapping in `src/app/globals.css`
- This maps CSS variables (e.g. `--border`, `--background`) to Tailwind v4 color tokens.

## Why
Fix runtime build error:
`Cannot apply unknown utility class border-border`

## How to test
1. Checkout branch
2. `npm i`
3. `npm run dev`
4. Confirm app starts without CSS error.